### PR TITLE
Added support for macOS because it does not compile

### DIFF
--- a/Sources/Extensions/PlatformColor.swift
+++ b/Sources/Extensions/PlatformColor.swift
@@ -1,0 +1,16 @@
+//
+//  PlatformColor.swift
+//  Orb
+//
+//  Created by Peter Salz on 12.11.24.
+//
+
+#if canImport(UIKit)
+import UIKit
+
+typealias PlatformColor = UIColor
+#elseif canImport(AppKit)
+import AppKit
+
+typealias PlatformColor = NSColor
+#endif

--- a/Sources/OrbView/OrbView.swift
+++ b/Sources/OrbView/OrbView.swift
@@ -202,4 +202,7 @@ public struct OrbView: View {
     OrbView(configuration: config)
         .aspectRatio(1, contentMode: .fit)
         .frame(maxWidth: 120)
+        #if os(macOS)
+        .padding()
+        #endif
 }


### PR DESCRIPTION
Replaced UIColor with NSColor if compiling for macOS, and implemented a macOS-only method to create particle texture.

Please checkout the preview when compiling for macOS, it works just fine now. 